### PR TITLE
Mobile device interaction enhancement

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,17 +11,16 @@ svg {
   position: relative;
 }
 
-path {
-  fill: #FED976;
+.county,
+.hover {
   stroke: #fff;
   stroke-width: 1.5px;
 }
 
-county {
-  fill: #FED976;
-  stroke: #fff;
-  stroke-width: 1.5px;
+.hover {
+  opacity: .5
 }
+
 .info {
     padding: 6px 8px;
     font: 14px/16px Arial, Helvetica, sans-serif;
@@ -30,20 +29,14 @@ county {
     box-shadow: 0 0 15px rgba(0,0,0,0.2);
     border-radius: 5px;
 }
+
 .info h4 {
     margin: 0 0 5px;
     color: #545454;
 }
+
 .info b {
     color: #545454;
-}
-.county {
-      stroke: #fff;
-
-}
-.hover {
-    stroke: #fff;
-    opacity: .5
 }
 
 </style>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,9 @@ svg {
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="//d3js.org/d3.v3.min.js" charset="utf-8"></script>
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.2.1.min.js"
+  integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
+  crossorigin="anonymous"></script>
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css">
   <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
 </head>

--- a/index.html
+++ b/index.html
@@ -122,6 +122,7 @@ d3.json("opencounties.geojson", function(error, collection) {
 
   /* Select a feature and update the info window */
   function selectFeature(e) {
+    d3.select("*").attr("class","");
     info.update("<h4>" + e.properties.COUNTYNAME + " County</h4><b>" + e.properties.STATUSTEXT + "</b><br />" +
     (e.properties.OPENYEAR != null ? "<b>Year Opened: " + e.properties.OPENYEAR + "</b><br />": "" ) +
     (e.properties.PLCYYEAR != null ? "<b>Policy Approved: " + e.properties.PLCYYEAR + "</b>" : "" )

--- a/index.html
+++ b/index.html
@@ -40,11 +40,11 @@ county {
 .county {
       stroke: #fff;
 
-    }
-    .hover {
-        stroke: #fff;
-        opacity: .5
-    }
+}
+.hover {
+    stroke: #fff;
+    opacity: .5
+}
 
 </style>
 <head>
@@ -53,10 +53,8 @@ county {
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="//d3js.org/d3.v3.min.js" charset="utf-8"></script>
-  <link rel="stylesheet" href="//unpkg.com/leaflet@1.1.0/dist/leaflet.css"
-    integrity="sha512-wcw6ts8Anuw10Mzh9Ytw4pylW8+NAD4ch3lqm9lzAsTxg0GFeJgoAtxuCLREZSC5lUXdVyo/7yfsqFjQ4S+aKw=="
-    crossorigin=""/>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.5/leaflet.js"></script>
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css">
+  <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
 </head>
 
 <div id="map">
@@ -93,23 +91,16 @@ d3.json("opencounties.geojson", function(error, collection) {
     .attr("d", path)
     .attr("class", "county")
     .style("fill", function(d) { return color(d.properties.OPENSTATUS); })
-    .on("touch", function(d) {
-      info.update("<h4>" + d.properties.COUNTYNAME + " County</h4><b>" + d.properties.STATUSTEXT + "</b><br />" + (d.properties.OPENYEAR != null ? "<b>Year Opened: " + d.properties.OPENYEAR + "</b><br />": "" ) + (d.properties.PLCYYEAR != null ? "<b>Policy Approved: " + d.properties.PLCYYEAR + "</b>" : "" ) );
-      d3.select(this).attr("class","hover");})
-    .on ("mouseover", function(d) {
-      //d3.select("info").text(d.properties.COUNTYNAME);
-    info.update("<h4>" + d.properties.COUNTYNAME + " County</h4><b>" + d.properties.STATUSTEXT + "</b><br />" + (d.properties.OPENYEAR != null ? "<b>Year Opened: " + d.properties.OPENYEAR + "</b><br />": "" ) + (d.properties.PLCYYEAR != null ? "<b>Policy Approved: " + d.properties.PLCYYEAR + "</b>" : "" ) );
-    //feature.attr("class", "hover");
-    d3.select(this).attr("class","hover");})
-    .on ("mouseout", function(d) {
-      //d3.select("info").text(d.properties.COUNTYNAME);
+    .on("mouseover", selectFeature)
+    .on("mouseout", function(d) {
       feature.attr("class", "county");
-    info.update('Hover over a County');
-
+      info.update('Hover over a County');
     });
 
 
   map.on("viewreset", reset);
+  feature.on("click", selectFeature); //Add click class (also tap for mobile)
+
   reset();
 
   // Reposition the SVG to cover the features.
@@ -127,6 +118,15 @@ d3.json("opencounties.geojson", function(error, collection) {
 
     feature.attr("d", path);
 
+  }
+
+  /* Select a feature and update the info window */
+  function selectFeature(e) {
+    info.update("<h4>" + e.properties.COUNTYNAME + " County</h4><b>" + e.properties.STATUSTEXT + "</b><br />" +
+    (e.properties.OPENYEAR != null ? "<b>Year Opened: " + e.properties.OPENYEAR + "</b><br />": "" ) +
+    (e.properties.PLCYYEAR != null ? "<b>Policy Approved: " + e.properties.PLCYYEAR + "</b>" : "" )
+  );
+    d3.select(this).attr("class","hover");
   }
 
   // Use Leaflet to implement a D3 geometric transformation.
@@ -152,3 +152,6 @@ info.update = function (htmltxt) {
 
 info.addTo(map);
 </script>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@ county {
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="//d3js.org/d3.v3.min.js" charset="utf-8"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css">
   <script src="//cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
 </head>
@@ -122,7 +123,7 @@ d3.json("opencounties.geojson", function(error, collection) {
 
   /* Select a feature and update the info window */
   function selectFeature(e) {
-    d3.select("*").attr("class","");
+    $("path").removeClass("hover").addClass("county")
     info.update("<h4>" + e.properties.COUNTYNAME + " County</h4><b>" + e.properties.STATUSTEXT + "</b><br />" +
     (e.properties.OPENYEAR != null ? "<b>Year Opened: " + e.properties.OPENYEAR + "</b><br />": "" ) +
     (e.properties.PLCYYEAR != null ? "<b>Policy Approved: " + e.properties.PLCYYEAR + "</b>" : "" )


### PR DESCRIPTION
# Functionality updates:
* Desktop functionality remains the same.
* Mobile devices will now see functionality when tapping (through the `click` event listener) by seeing the info window update and the map symbology change.

## What it looks like: 
### Before, on mobile devices:  
![Before look on mobile device](https://user-images.githubusercontent.com/5023024/31588507-4a12a690-b1b8-11e7-80e4-cb3496f28b8e.png)  

### After, on mobile devices:  
![After look on mobile device](https://user-images.githubusercontent.com/5023024/31588508-4ce45eb8-b1b8-11e7-8bd8-0e274f1a8e5a.png)  

## Caveats (library updates):  
* The update includes the latest jQuery library (dependent to remove the svg's `.hover` when a user clicks the map).  
* The Leaflet library was downgraded to 0.7.3 (unable to get the `click` functionality on the d3 layer working at higher versions of Leaflet).
* Ultimately, there is likely a better solution, but after some trial and error, went with the above changes.    

# Misc other updates: 
* CSS reformatting, removing unused CSS and making it easier to update content in the future.    
* Added end tags for the html's body and html document at the end of the index.html file, like so:  
```html  
</body>
</html>
```
